### PR TITLE
Additional UI Customization Options

### DIFF
--- a/Sources/DKImagePickerController/DKImagePickerController.swift
+++ b/Sources/DKImagePickerController/DKImagePickerController.swift
@@ -44,7 +44,10 @@ internal protocol DKImagePickerControllerObserver {
 ////////////////////////////////////////////////////////////////////////
 
 @objc
-open class DKImagePickerController: UINavigationController, DKImageBaseManagerObserver {
+open class DKUINavigationController: UINavigationController {}
+
+@objc
+open class DKImagePickerController: DKUINavigationController, DKImageBaseManagerObserver {
     
     /// Use UIDelegate to Customize the picker UI.
     @objc public var UIDelegate: DKImagePickerControllerBaseUIDelegate! {

--- a/Sources/DKImagePickerController/DKImagePickerControllerBaseUIDelegate.swift
+++ b/Sources/DKImagePickerController/DKImagePickerControllerBaseUIDelegate.swift
@@ -9,6 +9,12 @@
 import UIKit
 
 @objc
+public enum DKImagePickerGroupListPresentationStyle: Int {
+    case popover
+    case presented
+}
+
+@objc
 public protocol DKImagePickerControllerUIDelegate {
     
     /**
@@ -67,7 +73,11 @@ public protocol DKImagePickerControllerUIDelegate {
     
     func imagePickerControllerCollectionVideoCell() -> DKAssetGroupDetailBaseCell.Type
 
+    func imagePickerControllerGroupCell() -> DKAssetGroupCellType.Type
+
     func imagePickerControllerSelectGroupButton(_ imagePickerController: DKImagePickerController, selectedGroup: DKAssetGroup) -> UIButton
+
+    func imagePickerControllerGroupListPresentationStyle() -> DKImagePickerGroupListPresentationStyle
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -220,6 +230,10 @@ open class DKImagePickerControllerBaseUIDelegate: NSObject, DKImagePickerControl
         return DKAssetGroupDetailVideoCell.self
     }
 
+    open func imagePickerControllerGroupCell() -> DKAssetGroupCellType.Type {
+        return DKAssetGroupCell.self
+    }
+
     open func imagePickerControllerSelectGroupButton(_ imagePickerController: DKImagePickerController, selectedGroup: DKAssetGroup) -> UIButton {
         let button = self.createSelectGroupButtonIfNeeded()
         let groupsCount = self.imagePickerController.groupDataManager.groupIds?.count ?? 0
@@ -227,6 +241,10 @@ open class DKImagePickerControllerBaseUIDelegate: NSObject, DKImagePickerControl
         button.sizeToFit()
         button.isEnabled = groupsCount > 1
         return button
+    }
+
+    open func imagePickerControllerGroupListPresentationStyle() -> DKImagePickerGroupListPresentationStyle {
+        return .popover
     }
 }
 

--- a/Sources/DKImagePickerController/DKImagePickerControllerBaseUIDelegate.swift
+++ b/Sources/DKImagePickerController/DKImagePickerControllerBaseUIDelegate.swift
@@ -66,6 +66,8 @@ public protocol DKImagePickerControllerUIDelegate {
     func imagePickerControllerCollectionCameraCell() -> DKAssetGroupDetailBaseCell.Type
     
     func imagePickerControllerCollectionVideoCell() -> DKAssetGroupDetailBaseCell.Type
+
+    func imagePickerControllerSelectGroupButton(_ imagePickerController: DKImagePickerController, selectedGroup: DKAssetGroup) -> UIButton
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -76,6 +78,7 @@ open class DKImagePickerControllerBaseUIDelegate: NSObject, DKImagePickerControl
     open weak var imagePickerController: DKImagePickerController!
     
     open var doneButton: UIButton?
+    open var selectGroupButton: UIButton?
     
     open func createDoneButtonIfNeeded() -> UIButton {
         if self.doneButton == nil {
@@ -87,6 +90,27 @@ open class DKImagePickerControllerBaseUIDelegate: NSObject, DKImagePickerControl
         }
         
         return self.doneButton!
+    }
+
+    open func createSelectGroupButtonIfNeeded() -> UIButton {
+        if self.selectGroupButton == nil {
+            let button = UIButton()
+
+            #if swift(>=4.0)
+            let globalTitleColor = UINavigationBar.appearance().titleTextAttributes?[NSAttributedString.Key.foregroundColor] as? UIColor
+            let globalTitleFont = UINavigationBar.appearance().titleTextAttributes?[NSAttributedString.Key.font] as? UIFont
+            #else
+            let globalTitleColor = UINavigationBar.appearance().titleTextAttributes?[NSForegroundColorAttributeName] as? UIColor
+            let globalTitleFont = UINavigationBar.appearance().titleTextAttributes?[NSFontAttributeName] as? UIFont
+            #endif
+
+            button.setTitleColor(globalTitleColor ?? UIColor.black, for: .normal)
+            button.titleLabel!.font = globalTitleFont ?? UIFont.boldSystemFont(ofSize: 18.0)
+
+            self.selectGroupButton = button
+        }
+        
+        return self.selectGroupButton!
     }
     
     open func updateDoneButtonTitle(_ button: UIButton) {
@@ -195,6 +219,14 @@ open class DKImagePickerControllerBaseUIDelegate: NSObject, DKImagePickerControl
     open func imagePickerControllerCollectionVideoCell() -> DKAssetGroupDetailBaseCell.Type {
         return DKAssetGroupDetailVideoCell.self
     }
-    
+
+    open func imagePickerControllerSelectGroupButton(_ imagePickerController: DKImagePickerController, selectedGroup: DKAssetGroup) -> UIButton {
+        let button = self.createSelectGroupButtonIfNeeded()
+        let groupsCount = self.imagePickerController.groupDataManager.groupIds?.count ?? 0
+        button.setTitle(selectedGroup.groupName + (groupsCount > 1 ? "  \u{25be}" : "" ), for: .normal)
+        button.sizeToFit()
+        button.isEnabled = groupsCount > 1
+        return button
+    }
 }
 

--- a/Sources/DKImagePickerController/Resource/Resources/en.lproj/DKImagePickerController.strings
+++ b/Sources/DKImagePickerController/Resource/Resources/en.lproj/DKImagePickerController.strings
@@ -14,6 +14,8 @@
 
 "permission.allow" = "Allow Access";
 
+"picker.albums" = "Albums";
+
 "picker.alert.ok" = "OK";
 
 "picker.select.title" = "Select(%@)";

--- a/Sources/DKImagePickerController/View/DKAssetGroupDetailVC.swift
+++ b/Sources/DKImagePickerController/View/DKAssetGroupDetailVC.swift
@@ -155,7 +155,7 @@ open class DKAssetGroupDetailVC: UIViewController,
         func setup() {
             self.resetCachedAssets()
             self.imagePickerController.groupDataManager.add(observer: self)
-            self.groupListVC = DKAssetGroupListVC(groupDataManager: self.imagePickerController.groupDataManager,
+            self.groupListVC = DKAssetGroupListVC(imagePickerController: self.imagePickerController,
                                                   defaultAssetGroup: self.imagePickerController.defaultAssetGroup,
                                                   selectedGroupDidChangeBlock: { [unowned self] (groupId) in
                                                     self.selectAssetGroup(groupId)
@@ -192,8 +192,15 @@ open class DKAssetGroupDetailVC: UIViewController,
 	}
     
     @objc func showGroupSelector() {
-        if let button = self.selectGroupButton {
-            DKPopoverViewController.popoverViewController(self.groupListVC, fromView: button)
+        switch self.imagePickerController.UIDelegate.imagePickerControllerGroupListPresentationStyle() {
+        case .popover:
+            if let button = self.selectGroupButton {
+                DKPopoverViewController.popoverViewController(self.groupListVC, fromView: button)
+            }
+        case .presented:
+            let navigationController = DKUINavigationController()
+            navigationController.setViewControllers([self.groupListVC], animated: false)
+            self.present(navigationController, animated: true, completion: nil)
         }
     }
     


### PR DESCRIPTION
Adds 3 new UI customization points via `UIDelegate`…

## Asset Group Title View:
`imagePickerControllerSelectGroupButton` returns a `UIButton` which can be customized to provide a custom title view (i.e. one that displays the current selected item count when multiselect is enabled). Defaults to the current button style and behavior.

## Group List Cells: 
`imagePickerControllerGroupCell()` returns a `DKAssetGroupCellType.Type` to allow for full customization of the cell. The existing `DKAssetGroupCell` adopts this protocol.

## Group List Presentation Style
 `imagePickerControllerGroupListPresentationStyle` returns a `DKImagePickerGroupListPresentationStyle` of `.popover` or `.presented` and the group list is displayed according to that preference (defaults to `popover`, the current behavior). This also creates a new `DKUINavigationController` for more precise appearance selector targeting. The title for the `presented` style needs localization.
