### PR TITLE
UIDelegate method to allow for customization of asset group list view controller 

### DIFF
--- a/Sources/DKImagePickerController/DKImagePickerControllerBaseUIDelegate.swift
+++ b/Sources/DKImagePickerController/DKImagePickerControllerBaseUIDelegate.swift
@@ -78,6 +78,8 @@ public protocol DKImagePickerControllerUIDelegate {
     func imagePickerControllerSelectGroupButton(_ imagePickerController: DKImagePickerController, selectedGroup: DKAssetGroup) -> UIButton
 
     func imagePickerControllerGroupListPresentationStyle() -> DKImagePickerGroupListPresentationStyle
+
+    func imagePickerControllerPrepareGroupListViewController(_ listViewController: UITableViewController)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -245,6 +247,10 @@ open class DKImagePickerControllerBaseUIDelegate: NSObject, DKImagePickerControl
 
     open func imagePickerControllerGroupListPresentationStyle() -> DKImagePickerGroupListPresentationStyle {
         return .popover
+    }
+
+    open func imagePickerControllerPrepareGroupListViewController(_ listViewController: UITableViewController) {
+        // nothing by default, override in subclasses to customize group list table view
     }
 }
 

--- a/Sources/DKImagePickerController/View/DKAssetGroupListVC.swift
+++ b/Sources/DKImagePickerController/View/DKAssetGroupListVC.swift
@@ -200,6 +200,8 @@ class DKAssetGroupListVC: UITableViewController, DKImageGroupDataManagerObserver
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        self.imagePickerController.UIDelegate.imagePickerControllerPrepareGroupListViewController(self)
+
         let cellType = self.imagePickerController.UIDelegate.imagePickerControllerGroupCell()
         self.tableView.register(cellType, forCellReuseIdentifier: DKImageGroupCellIdentifier)
         self.tableView.rowHeight = cellType.preferredHeight


### PR DESCRIPTION
New UIDelegate method to allow clients to customize group list tableview controller.

This is useful for things like setting `contentInset`, etc…